### PR TITLE
Do not use the local index with conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER John Kirkham <jakirkham@gmail.com>
 RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \
-        conda install -qy --use-local -n root notebook && \
+        conda install -qy -n root notebook && \
         python -m ipykernel install && \
         conda clean -tipsy ; \
     done ; \


### PR DESCRIPTION
Appears that `conda` has some bug where if one tries to install from the local index it gets fouled up trying to serialize some traceback. As we don't really need to use the local index here, this stops using it. Interestingly this didn't fail the build, but only failed the Python 2 portion. The Python 3 portion appears to have run through without issues interestingly.

xref: https://github.com/conda/conda/issues/3985