### PR TITLE
Fix tini's path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN for PYTHON_VERSION in 2 3; do \
     done ; \
     mkdir -p /notebooks
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks"]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks"]


### PR DESCRIPTION
As we have switched to the conda-forge package for `tini`, we need to update the path for running it.

xref: https://github.com/jakirkham/docker_centos_drmaa_conda/pull/39