### PR TITLE
Pin `jupyter_client` to `5.1.0` temporarily

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM nanshe/nanshe:latest
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 RUN for PYTHON_VERSION in 2 3; do \
+        # Pin `jupyter_client` to workaround an issue with `pytest`.
+        # Please see the linked PR.
+        #
+        # https://github.com/conda-forge/jupyter_client-feedstock/pull/14
+        #
+        echo "jupyter_client 5.1.0" >> "/opt/conda${PYTHON_VERSION}/conda-meta/pinned" && \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \
         conda install -qy -n root notebook && \


### PR DESCRIPTION
Adds a workaround of pinning `jupyter_client` to `5.1.0` in order to avoid some issues related to `jupyter_client`'s `pytest` requirement and its effect on `jupyter_nbextensions_configurator`.