### PR TITLE
Unpin `jupyter_client` (was `5.1.0`)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,6 @@ FROM nanshe/nanshe:latest
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 RUN for PYTHON_VERSION in 2 3; do \
-        # Pin `jupyter_client` to workaround an issue with `pytest`.
-        # Please see the linked PR.
-        #
-        # https://github.com/conda-forge/jupyter_client-feedstock/pull/14
-        #
-        echo "jupyter_client 5.1.0" >> "/opt/conda${PYTHON_VERSION}/conda-meta/pinned" && \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \
         conda install -qy -n root notebook && \


### PR DESCRIPTION
Reverts PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/5 ).

As the `jupyter_nbextensions_configurator` package in `conda-forge` has since switched to using `pip` to do the install and fixed its entry points to not use `setuptools` as of PR ( https://github.com/conda-forge/jupyter_nbextensions_configurator-feedstock/pull/22 ), there should no longer be an issue using the latest `jupyter_client`. So drop this pinning so that the most recent copy of `jupyter_client` is used and everything else that relies upon it.