### PR TITLE
Use `nanshe/nanshe:sge`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nanshe/nanshe:latest
+FROM nanshe/nanshe:sge
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 RUN for PYTHON_VERSION in 2 3; do \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,6 @@ FROM nanshe/nanshe:latest
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 RUN for PYTHON_VERSION in 2 3; do \
-        # Pin `jupyter_client` to workaround an issue with `pytest`.
-        # Please see the linked PR.
-        #
-        # https://github.com/conda-forge/jupyter_client-feedstock/pull/14
-        #
-        echo "jupyter_client 5.1.0" >> "/opt/conda${PYTHON_VERSION}/conda-meta/pinned" && \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \
         conda install -qy -n root notebook && \


### PR DESCRIPTION
As SGE is getting stripped from the images to allow easier deployment to more diverse environments (e.g. the cluster via Singularity images) ( https://github.com/nanshe-org/docker_nanshe/pull/26 ), add a build of this image that uses SGE in addition to the normal build, which will now be built without SGE.