### PR TITLE
Use `nanshe/nanshe:sge`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nanshe/nanshe:latest
+FROM nanshe/nanshe:sge
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 RUN for PYTHON_VERSION in 2 3; do \


### PR DESCRIPTION
As SGE is getting stripped from the images to allow easier deployment to more diverse environments (e.g. the cluster via Singularity images) ( https://github.com/nanshe-org/docker_nanshe/pull/26 ), add a build of this image that uses SGE in addition to the normal build, which will now be built without SGE.