### PR TITLE
Add call to `entrypoint_2.sh`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN for PYTHON_VERSION in 2 3; do \
     done ; \
     mkdir -p /notebooks
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks"]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN for PYTHON_VERSION in 2 3; do \
     done ; \
     mkdir -p /notebooks
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks" ]


### PR DESCRIPTION
Include a call to `entrypoint_2.sh` after `entrypoint.sh` as `entrypoint.sh` is now the entry point for the `jakirkham/centos_conda` image and `entrypoint_2.sh` is the entry point for the `jakirkham/centos_drmaa_conda` image. The latter being necessary for actually starting SGE.

xref: https://github.com/jakirkham/docker_centos_drmaa_conda/pull/44