### PR TITLE
Make `/notebooks` directory in `for`-loop (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM nanshe/nanshe:sge
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 RUN for PYTHON_VERSION in 2 3; do \
+        mkdir -p /notebooks && \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate root && \
         conda install -qy -n root notebook && \
         python -m ipykernel install && \
         conda clean -tipsy ; \
-    done ; \
-    mkdir -p /notebooks
+    done
 
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks" ]


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/11 ) for SGE.

As making the `/notebooks` directory outside the `for`-loop is causing some errors to get suppressed due to the `;`. Simply make the `/notebooks` directory in the `for`-loop and use `&&` to chain later commands to it. This way if installing packages with `conda` runs into issues, the failure will propagate to the Docker build and thus terminate the build as expected.