### PR TITLE
Make sure to deactivate `conda` (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ MAINTAINER John Kirkham <jakirkham@gmail.com>
 RUN for PYTHON_VERSION in 2 3; do \
         mkdir -p /notebooks && \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
-        . ${INSTALL_CONDA_PATH}/bin/activate root && \
+        . ${INSTALL_CONDA_PATH}/bin/activate && \
         conda install -qy -n root notebook && \
         python -m ipykernel install && \
-        conda clean -tipsy ; \
+        conda clean -tipsy && \
+        . ${INSTALL_CONDA_PATH}/bin/deactivate ; \
     done
 
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks" ]


### PR DESCRIPTION
Backport PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/12 ) for SGE.

When looping through the `conda` installs, make sure to deactivate each one after we are done using that `conda` installation. Also drop `root` from `activate` as `root` is already assumed if no environment name is specified.