### PR TITLE
Remove the `.conda` directory in `root`'s home (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda install -qy -n root notebook && \
         python -m ipykernel install && \
         conda clean -tipsy && \
-        . ${INSTALL_CONDA_PATH}/bin/deactivate ; \
+        . ${INSTALL_CONDA_PATH}/bin/deactivate && \
+        rm -rf ~/.conda ; \
     done
 
 ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks" ]


### PR DESCRIPTION
Backport PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/13 ) for SGE.

When installing and upgrading packages with `conda`, it creates a `.conda` directory in `root`'s home. This is used by `conda` as a fallback if it lacks permissions to `conda`'s install prefix. However leaving `root`'s `.conda` directory could mess with a user created one while running the container. So this cleans up the `.conda` directory in `root`'s home after all of the installing and upgrading is complete. This should make the container more usable with Singularity.