### PR TITLE
Install Python kernels in conda environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate && \
         conda install -qy -n root notebook && \
-        python -m ipykernel install && \
+        python -m ipykernel install --prefix "/opt/conda2" && \
+        python -m ipykernel install --prefix "/opt/conda3" && \
         conda clean -tipsy && \
         . ${INSTALL_CONDA_PATH}/bin/deactivate && \
         rm -rf ~/.conda ; \


### PR DESCRIPTION
Instead of letting Jupyter install the Python kernels in `/usr/local/share/jupyter/kernels`, install the Python kernels in both `conda` environments.