### PR TITLE
Support conda 4.4+ (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ MAINTAINER John Kirkham <jakirkham@gmail.com>
 RUN for PYTHON_VERSION in 2 3; do \
         mkdir -p /notebooks && \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
-        . ${INSTALL_CONDA_PATH}/bin/activate && \
+        . "${INSTALL_CONDA_PATH}/etc/profile.d/conda.sh" && \
+        conda activate base && \
         conda install -qy notebook && \
         python -m ipykernel install --prefix "/opt/conda2" && \
         python -m ipykernel install --prefix "/opt/conda3" && \
         conda clean -tipsy && \
-        . ${INSTALL_CONDA_PATH}/bin/deactivate && \
+        conda deactivate && \
         rm -rf ~/.conda ; \
     done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         mkdir -p /notebooks && \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . ${INSTALL_CONDA_PATH}/bin/activate && \
-        conda install -qy -n root notebook && \
+        conda install -qy notebook && \
         python -m ipykernel install --prefix "/opt/conda2" && \
         python -m ipykernel install --prefix "/opt/conda3" && \
         conda clean -tipsy && \


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/21 ) for SGE.

Refresh the activation/deactivation procedure to be compatible with `conda` 4.4+.