### PR TITLE
Add Jupyter Notebook extras (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         python -m ipykernel install --prefix "/opt/conda2" && \
         python -m ipykernel install --prefix "/opt/conda3" && \
         conda install -qy ipywidgets && \
+        conda install -qy jupyter_contrib_nbextensions && \
         conda clean -tipsy && \
         conda deactivate && \
         rm -rf ~/.conda ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda install -qy notebook && \
         python -m ipykernel install --prefix "/opt/conda2" && \
         python -m ipykernel install --prefix "/opt/conda3" && \
+        conda install -qy ipywidgets && \
         conda clean -tipsy && \
         conda deactivate && \
         rm -rf ~/.conda ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         python -m ipykernel install --prefix "/opt/conda3" && \
         conda install -qy ipywidgets && \
         conda install -qy jupyter_contrib_nbextensions && \
+        conda install -qy nbconvert && \
         conda clean -tipsy && \
         conda deactivate && \
         rm -rf ~/.conda ; \


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/23 ) for SGE.

Provides a few useful extras alongside the Jupyter Notebook install. These are useful for the workflow (downstream of this) and will help lighten its CI and maintenance. However these are also useful in the container on their own. So go ahead and add them. In particular this adds the following...

* ipywidgets
* jupyter_contrib_nbextensions
* nbconvert

These are configured correctly from their install with all post-link steps run exposing whatever UIs (if any) they might to the notebook UI. Avoids manually running these post-link steps as was the case before in the workflow, which should keep their maintenance minimal.