### PR TITLE
Replace `python3` with `python`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ RUN for PYTHON_VERSION in 2 3; do \
         rm -rf ~/.conda ; \
     done
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks" ]


### PR DESCRIPTION
As activation of the `conda` environment now works correctly, there is no need to specify that `python3` should be used. Instead by simply specifying `python`, the right `python` from the active `conda` environment (which will be the one with Python 3) will be used. So just use `python` and let `conda` find the correct one.