### PR TITLE
Patch Python 2/3 kernels to use wrapper scripts (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,17 @@ RUN for PYTHON_VERSION in 2 3; do \
         . "${INSTALL_CONDA_PATH}/etc/profile.d/conda.sh" && \
         conda activate base && \
         conda install -qy notebook && \
-        python -m ipykernel install --prefix "/opt/conda2" && \
-        python -m ipykernel install --prefix "/opt/conda3" && \
         conda install -qy ipywidgets && \
         conda install -qy jupyter_contrib_nbextensions && \
         conda install -qy nbconvert && \
         conda clean -tipsy && \
         conda deactivate && \
+        python${PYTHON_VERSION} -m ipykernel install --name "python${PYTHON_VERSION}" --prefix "/opt/conda2" && \
+        sed -i "s/\/opt\/conda${PYTHON_VERSION}\/bin\/python/\/usr\/local\/bin\/python${PYTHON_VERSION}/g" \
+               "/opt/conda2/share/jupyter/kernels/python${PYTHON_VERSION}/kernel.json" && \
+        python${PYTHON_VERSION} -m ipykernel install --name "python${PYTHON_VERSION}" --prefix "/opt/conda3" && \
+        sed -i "s/\/opt\/conda${PYTHON_VERSION}\/bin\/python/\/usr\/local\/bin\/python${PYTHON_VERSION}/g" \
+               "/opt/conda3/share/jupyter/kernels/python${PYTHON_VERSION}/kernel.json" && \
         rm -rf ~/.conda ; \
     done
 


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/27 ) for SGE.

Currently the Jupyter Notebook will open each Python kernel, but not activate their respective environment. This is a problem if the user tries to run anything as a shell command as it will not run in the correct environment. Thus it will pickup the wrong `pip` or `conda` environment. In the best case, this results in an unusual result like showing the wrong `python` is used. In the worst case, it could result in changing the wrong environment or submitting info from the wrong environment in a bug report.

To fix this, we install the `ipykernel` just as before, but we use a hack to replace the `python` path to not point at the `python` in the `conda` environment, but instead at the versioned `python` wrapper script in `/usr/local/bin`. As that wrapper script activates the correct `conda` environment before calling `python` to start the Jupyter Notebook kernel, the user is place in a correctly activated environment. All calls to `conda`, `python`, and `pip` will work as expected and point at the correct executables. Thus along the Jupyter Notebook kernels to seamless interoperate with the `conda` environment expected. Should make debugging and further modification painless for the user.