### PR TITLE
Install the nbserverproxy conda-forge package too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda install -qy ipywidgets && \
         conda install -qy jupyter_contrib_nbextensions && \
         conda install -qy nbconvert && \
+        conda install -qy nbserverproxy && \
         conda clean -tipsy && \
         conda deactivate && \
         python${PYTHON_VERSION} -m ipykernel install --name "python${PYTHON_VERSION}" --prefix "/opt/conda2" && \


### PR DESCRIPTION
This allows other neighboring port connections to the host machine running the Jupyter notebook to be proxied as well. Can be helpful when using the Dask Distributed's Bokeh-based Dashboard remotely (thus avoiding an extra SSH port forwarding connection). Normally `nbserverproxy` needs to be enabled as a Jupyter extension, but this isn't needed with the `conda` package as this will be run as part of the post-link script.