### PR TITLE
Skip installing `nbserverproxy` on Python 2 (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda install -qy ipywidgets && \
         conda install -qy jupyter_contrib_nbextensions && \
         conda install -qy nbconvert && \
-        conda install -qy nbserverproxy && \
+        ( conda install -qy nbserverproxy || true ) && \
         conda clean -tipsy && \
         conda deactivate && \
         python${PYTHON_VERSION} -m ipykernel install --name "python${PYTHON_VERSION}" --prefix "/opt/conda2" && \


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/31 ) for SGE.
Follow-up to PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/30 )

As `nbserverproxy` is not Python 2 compatible, skip installing it on Python 2. We don't need it there as we run the Jupyter notebook under Python 3 anyways (even if we do use a Python 2 kernel). So this should always work anyways.