### PR TITLE
Pin Tornado to 5.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . "${INSTALL_CONDA_PATH}/etc/profile.d/conda.sh" && \
         conda activate base && \
+        echo "tornado 5.0.2" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         conda install -qy notebook && \
         conda install -qy ipywidgets && \
         conda install -qy jupyter_contrib_nbextensions && \


### PR DESCRIPTION
Currently Tornado 5.1.0 breaks nbserverproxy. While there appears to be a fix upstream, it has not yet been released. For now pin Tornado to the latest of the 5.0.x series (i.e. 5.0.2), so that nbserverproxy can work correctly. This pin can be released once a new release of nbserverproxy comes out.