### PR TITLE
Change `ip` argument from `*` to `0.0.0.0` (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN for PYTHON_VERSION in 2 3; do \
         rm -rf ~/.conda ; \
     done
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" , "--notebook-dir=/notebooks" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=0.0.0.0" , "--notebook-dir=/notebooks" ]


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/35 ) for SGE.

As Jupyter Notebook 5.7.0 changed some behavior, which has caused `--ip=*` to fail, switch to `--ip=0.0.0.0`. This has the same semantic meaning; though, has the benefit of working Jupyter Notebook pre-5.7.0 and 5.7.0+.