### PR TITLE
Drop Tornado pin (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN for PYTHON_VERSION in 2 3; do \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
         . "${INSTALL_CONDA_PATH}/etc/profile.d/conda.sh" && \
         conda activate base && \
-        echo "tornado 5.0.2" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         conda install -qy notebook && \
         conda install -qy ipywidgets && \
         conda install -qy jupyter_contrib_nbextensions && \


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_notebook/pull/37 ) for SGE.

Reverts https://github.com/nanshe-org/docker_nanshe_notebook/pull/34

As nbserverproxy has seen a few recent releases with the fix for Tornado 5.1.0, go ahead and drop this Tornado 5.0.2 pin.