### PR TITLE
Set JUPYTER_RUNTIME_DIR to the user's home directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN for PYTHON_VERSION in 2 3; do \
         rm -rf ~/.conda ; \
     done
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=0.0.0.0" , "--notebook-dir=/notebooks" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=0.0.0.0", "--notebook-dir=/notebooks" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM nanshe/nanshe:latest
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
+ADD entrypoint.sh /usr/share/docker/entrypoint_2.sh
+
 RUN for PYTHON_VERSION in 2 3; do \
         mkdir -p /notebooks && \
         export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN for PYTHON_VERSION in 2 3; do \
         rm -rf ~/.conda ; \
     done
 
-ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=0.0.0.0", "--notebook-dir=/notebooks" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=0.0.0.0", "--notebook-dir=/notebooks" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+# Place the Jupyter runtime directory in the user's home directory.
+export JUPYTER_RUNTIME_DIR="$HOME/.local/share/jupyter/runtime"
+
+
+exec "$@"


### PR DESCRIPTION
Adds a script that is run in the `ENTRYPOINT`, which sets `JUPYTER_RUNTIME_DIR` to a location in the user's home directory. This is the same as what it would default to otherwise if `XDG_RUNTIME_DIR` and `JUPYTER_RUNTIME_DIR` were not set. Should allow us to override the location used on the cluster easily thus avoiding needing to muck with the user's `.bash_profile` for this change.